### PR TITLE
refactor: migrate to new raindrop api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ nix run github:thenbe/fzf-raindrop
 > Bookmarks will be pulled _automatically_ only when you launch `fzf-raindrop` for the first time. After that, you can pull the latest bookmarks by running the following command.
 
 ```sh
-FZF_RAINDROP_COOKIE="..." fzf-raindrop update
+FZF_RAINDROP_TOKEN="..." fzf-raindrop update
 
 # or using nix
-FZF_RAINDROP_COOKIE="..." nix run github:thenbe/fzf-raindrop -- update
+FZF_RAINDROP_TOKEN="..." nix run github:thenbe/fzf-raindrop -- update
 ```
 
 ### Key maps
@@ -64,18 +64,26 @@ Clone this repo and make sure you have the required [dependencies](#dependencies
 
 ## Configuration
 
-| Env Var                 | Required | Default                           | Example                | Notes                         |
-| ----------------------- | -------- | --------------------------------- | ---------------------- | ----------------------------- |
-| `OPENER`                | no       | `xdg-open`, `open`                | "mimeo" or "firefox"   | Program used to launch URLs   |
-| `FZF_RAINDROP_COOKIE`   | yes      |                                   | "connect.sid=s%123..." | Get from browser's devtools\* |
-| `FZF_RAINDROP_DATA_DIR` |          | `$HOME/.local/share/fzf-raindrop` |                        |                               |
+| Env Var                 | Required | Default                           | Example              | Notes                       |
+| ----------------------- | -------- | --------------------------------- | -------------------- | --------------------------- |
+| `OPENER`                | no       | `xdg-open`, `open`                | "mimeo" or "firefox" | Program used to launch URLs |
+| `FZF_RAINDROP_TOKEN`    | yes      |                                   | "a1b2c3..."          | Get from Raindrop app\*     |
+| `FZF_RAINDROP_DATA_DIR` |          | `$HOME/.local/share/fzf-raindrop` |                      |                             |
 
-> \* Unfortunately, the [Raindrop API](https://developer.raindrop.io/) does not expose an endpoint to [export all bookmarks](https://help.raindrop.io/backups/#downloading-a-backup) using a bearer token. See [issue](https://github.com/thenbe/fzf-raindrop/issues/1).
+### Generate a Raindrop token
+
+A test token is [sufficient](https://developer.raindrop.io/v1/authentication/token) for our needs. To create one:
+
+1. Go to the [Raindrop app settings](https://app.raindrop.io/settings/integrations).
+1. Click `Create new app`. Name it `fzf-raindrop`.
+1. Click on the item you just created.
+1. Click on `Create test token`.
 
 ## Dependencies
 
 - [`duckdb`](https://github.com/duckdb/duckdb)
 - [`fzf`](https://github.com/junegunn/fzf)
+- `jq`
 
 ## Contributing
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
           nativeBuildInputs = [ pkgs.makeWrapper ];
           postFixup = with pkgs; ''
             wrapProgram "$out/bin/fzf-raindrop" \
-                --prefix PATH : "${lib.makeBinPath [ duckdb fzf ]}"
+                --prefix PATH : "${lib.makeBinPath [ duckdb fzf jq ]}"
           '';
           installPhase = ''
             mkdir -p $out/bin

--- a/fzf-raindrop
+++ b/fzf-raindrop
@@ -10,11 +10,37 @@ MODIFIED=$(stat -c %y "$DATA_FILE" | cut -d'.' -f1)
 # Allow users to define a custom OPENER, fallback to auto-detection if not defined
 OPENER=${OPENER:-$(command -v xdg-open || command -v open)}
 
+# Get list of backups
+get_backups() {
+	curl 'https://api.raindrop.io/rest/v1/backups' \
+		-H "Authorization: Bearer $FZF_RAINDROP_TOKEN"
+}
+
+# Get latest backup id
+get_latest_backup_id() {
+	get_backups | jq -r '.items | max_by(.created) | ._id'
+}
+
+# Get latest backup creation date
+get_latest_backup_date() {
+	get_backups | jq -r '.items | max_by(.created) | .created'
+}
+
 # Download all bookmarks from Raindrop
 download_bookmarks() {
 	echo "Pulling latest bookmarks from Raindrop"
-	curl 'https://api.raindrop.io/v1/raindrops/0/export.csv' \
-		-H "Cookie: $FZF_RAINDROP_COOKIE" \
+
+	echo "Looking for most recent backup..."
+	# Look for the most recent backup
+	BACKUP_ID=$(get_latest_backup_id)
+	BACKUP_DATE=$(get_latest_backup_date)
+	echo "Found most recent backup. backup_created: $BACKUP_DATE, backup_id: $BACKUP_ID"
+
+	# Download backup file
+	echo "Downloading most recent backup..."
+	curl -L "https://api.raindrop.io/rest/v1/backup/$BACKUP_ID.csv" \
+		-H "Authorization: Bearer $FZF_RAINDROP_TOKEN" \
+		--compressed \
 		-o "$DATA_FILE_TEMP"
 
 	mv "$DATA_FILE_TEMP" "$DATA_FILE"
@@ -78,7 +104,7 @@ COPY (
 ) TO '/dev/stdout' WITH (FORMAT CSV, HEADER)
 	" |
 	# xsv table --width=2 --condense=75 |
-	fzf --multi --layout=reverse --header-lines=1 --header "Updated: $MODIFIED" --history="$FZF_BOOKMARKS_HISTORY" |
+	fzf --multi --layout=reverse --header-lines=1 --header "Downloaded at: $MODIFIED" --history="$FZF_BOOKMARKS_HISTORY" |
 	awk --field-separator=, '{print $1}' |
 	xargs -I {} duckdb -c "COPY(SELECT url FROM '$DATA_FILE' WHERE id_2 = {}) TO '/dev/stdout'" |
 	xargs -I {} "$OPENER" "{}"


### PR DESCRIPTION
closes #1

As of 2024-08-28, the raindrop endpoint we rely on to fetch backups has been taken down (returns a `404: NOT FOUND`). Instead, another endpoint has [taken](https://github.com/raindropio/developer-site/commit/026c957173fa2245687154ef66a8c269690a8f03) its place.

The good news is that the new endpoint is [documented](https://developer.raindrop.io/v1/backups). The bad news is that the new endpoint may not return "fresh" results. It returns data that is typically 0 to 24 hours old.

This PR migrates the code to use the new documented endpoint.

### 🔴 Breaking changes:
  - A new dependency (`jq`) is now required. You may already have it installed, check by running `jq --version`.
  - A new environment variable `FZF_RAINDROP_TOKEN` is now required. See the [README.md](https://github.com/thenbe/fzf-raindrop?#generate-a-raindrop-token) for instructions on how to generate the token.

### Changes:
  - The environment variable `FZF_RAINDROP_COOKIE` is no longer used.